### PR TITLE
prost-build: Allow generation without FileDescriptor.source_info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
   "prost-derive",
   "prost-types",
   "protobuf",
+  "protoc-gen-prost",
   "tests",
   "tests-2015",
   "tests-no-std",

--- a/prost-build/src/ast.rs
+++ b/prost-build/src/ast.rs
@@ -1,7 +1,7 @@
 use prost_types::source_code_info::Location;
 
 /// Comments on a Protobuf item.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Comments {
     /// Leading detached blocks of comments.
     pub leading_detached: Vec<Vec<String>>,

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -217,6 +217,25 @@ impl Default for BytesType {
     }
 }
 
+const BTREE_MAP: &str = "btree_map";
+const BYTES: &str = "bytes";
+const FIELD_ATTR: &str = "field_attr";
+const TYPE_ATTR: &str = "type_attr";
+const COMPILE_WELL_KNOWN_TYPES: &str = "compile_well_known_types";
+const DISABLE_COMMENTS: &str = "disable_comments";
+const EXTERN_PATH: &str = "extern_path";
+const RETAIN_ENUM_PREFIX: &str = "retain_enum_prefix";
+pub const PROTOC_OPTS: [&str; 8] = [
+    BTREE_MAP,
+    BYTES,
+    FIELD_ATTR,
+    TYPE_ATTR,
+    COMPILE_WELL_KNOWN_TYPES,
+    DISABLE_COMMENTS,
+    EXTERN_PATH,
+    RETAIN_ENUM_PREFIX,
+];
+
 /// Configuration options for Protobuf code generation.
 ///
 /// This configuration builder can be used to set non-default code generation options.
@@ -239,6 +258,41 @@ impl Config {
     /// Creates a new code generator configuration with default options.
     pub fn new() -> Config {
         Config::default()
+    }
+
+    /// Creates a new code generator configuration with default options, overriden from parameters
+    /// passed to the protoc command line.
+    ///
+    /// Format is opt1=value,opt2=value
+    pub fn new_from_opts(opts: &str, log_unknown: bool) -> Config {
+        let mut cfg = Config::new();
+        cfg.opts(opts, log_unknown);
+        cfg
+    }
+
+    /// Configure the code generator with the inlined options. To be used by protoc plugins.
+    ///
+    /// Format is opt1=value,opt2=value
+    pub fn opts(&mut self, opts: &str, log_unknown: bool) -> &mut Config {
+        let opts = opts
+            .split(',')
+            .map(|opt| opt.split('=').collect::<Vec<_>>());
+        for opt in opts {
+            match opt.as_slice() {
+                [""] => (),
+                [BTREE_MAP, v] => self.map_type.insert(v.to_string(), MapType::BTreeMap),
+                [BYTES, v] => self.bytes_type.insert(v.to_string(), BytesType::Bytes),
+                [FIELD_ATTR, k, v] => self.field_attributes.insert(k.to_string(), v.to_string()),
+                [TYPE_ATTR, k, v] => self.type_attributes.insert(k.to_string(), v.to_string()),
+                [COMPILE_WELL_KNOWN_TYPES] => self.prost_types = false,
+                [DISABLE_COMMENTS, v] => self.disable_comments.insert(v.to_string(), ()),
+                [EXTERN_PATH, k, v] => self.extern_paths.push((k.to_string(), v.to_string())),
+                [RETAIN_ENUM_PREFIX] => self.strip_enum_prefix = false,
+                _ if log_unknown => eprintln!("prost: Unknown option `{}`", opt.join("=")),
+                _ => (),
+            }
+        }
+        self
     }
 
     /// Configure the code generator to generate Rust [`BTreeMap`][1] fields for Protobuf

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -117,7 +117,7 @@ mod lib_generator;
 mod message_graph;
 mod path;
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::default;
 use std::env;
 use std::ffi::{OsStr, OsString};
@@ -228,7 +228,8 @@ const DISABLE_COMMENTS: &str = "disable_comments";
 const EXTERN_PATH: &str = "extern_path";
 const RETAIN_ENUM_PREFIX: &str = "retain_enum_prefix";
 const MOD_RS: &str = "mod_rs";
-pub const PROTOC_OPTS: [&str; 9] = [
+const GEN_CRATE: &str = "gen_crate";
+pub const PROTOC_OPTS: [&str; 10] = [
     BTREE_MAP,
     BYTES,
     FIELD_ATTR,
@@ -238,6 +239,7 @@ pub const PROTOC_OPTS: [&str; 9] = [
     EXTERN_PATH,
     RETAIN_ENUM_PREFIX,
     MOD_RS,
+    GEN_CRATE,
 ];
 
 /// Configuration options for Protobuf code generation.
@@ -257,6 +259,7 @@ pub struct Config {
     protoc_args: Vec<OsString>,
     disable_comments: PathMap<()>,
     mod_rs: bool,
+    manifest_tpl: Option<PathBuf>,
 }
 
 impl Config {
@@ -294,6 +297,7 @@ impl Config {
                 [EXTERN_PATH, k, v] => self.extern_paths.push((k.to_string(), v.to_string())),
                 [RETAIN_ENUM_PREFIX] => self.strip_enum_prefix = false,
                 [MOD_RS] => self.mod_rs = true,
+                [GEN_CRATE, v] => self.manifest_tpl = Some(v.into()),
                 _ if log_unknown => eprintln!("prost: Unknown option `{}`", opt.join("=")),
                 _ => (),
             }
@@ -747,6 +751,20 @@ impl Config {
         self
     }
 
+    /// Generate a full crate based on a `Cargo.toml` template.
+    ///
+    /// The output directory will contain the crate and not the built files directly, in `gen/`
+    /// folder. Each `proto` package will get its own feature flag, with proper dependency solving.
+    /// The `Cargo.toml` must contain `{{ features }}` string where all crate features will be
+    /// inserted.
+    pub fn generate_crate<P>(&mut self, manifest_template: P) -> &mut Self
+    where
+        P: Into<PathBuf>,
+    {
+        self.manifest_tpl = Some(manifest_template.into());
+        self
+    }
+
     /// Compile `.proto` files into Rust files during a Cargo build with additional code generator
     /// configuration options.
     ///
@@ -839,8 +857,7 @@ impl Config {
 
         let modules = self.generate(file_descriptor_set.file)?;
         for (module, content) in modules {
-            let mut filename = module.join(".");
-            filename.push_str(".rs");
+            let filename = self.filename(&module);
 
             let output_path = target.join(&filename);
 
@@ -866,7 +883,7 @@ impl Config {
         match self.generate(req.proto_file) {
             Ok(modules) => {
                 let f = modules.into_iter().map(|(module, content)| File {
-                    name: Some(module.join(".") + ".rs"),
+                    name: Some(self.filename(&module)),
                     insertion_point: None,
                     content: Some(content),
                     generated_code_info: None,
@@ -885,9 +902,24 @@ impl Config {
         }
     }
 
+    fn filename(&self, module: &Module) -> String {
+        let (prefix, suffix) = match (self.manifest_tpl.is_some(), module.as_slice()) {
+            (true, [n]) if n == "lib" => ("src/", ".rs"),
+            (true, [n]) if n == "Cargo.toml" => ("", ""),
+            (true, _) => ("gen/", ".rs"),
+            (false, _) => ("", ".rs"),
+        };
+        prefix.to_owned() + &module.join(".") + suffix
+    }
+
     fn generate(&mut self, files: Vec<FileDescriptorProto>) -> Result<HashMap<Module, String>> {
         let mut modules = HashMap::new();
         let mut packages = HashMap::new();
+        let deps = self
+            .manifest_tpl
+            .is_some()
+            .then(|| self.build_deps(&files))
+            .unwrap_or_default();
 
         let message_graph = MessageGraph::new(&files)
             .map_err(|error| Error::new(ErrorKind::InvalidInput, error))?;
@@ -913,13 +945,18 @@ impl Config {
             }
         }
 
-        if self.mod_rs {
+        if self.mod_rs || self.manifest_tpl.is_some() {
             let mut mods = Mod::default();
             for (module, _) in &modules {
                 mods.push(module);
             }
-            let mut buf = modules.entry(vec!["mod".to_owned()]).or_default();
+            let name = self.manifest_tpl.is_some().then(|| "lib").unwrap_or("mod");
+            let mut buf = modules.entry(vec![name.to_owned()]).or_default();
             LibGenerator::generate_librs(self, &mods, &mut buf);
+        }
+        if let Some(tpl) = self.manifest_tpl.clone() {
+            let mut buf = modules.entry(vec!["Cargo.toml".to_owned()]).or_default();
+            LibGenerator::generate_manifest(self, tpl, deps, &mut buf);
         }
 
         Ok(modules)
@@ -931,6 +968,26 @@ impl Config {
             .filter(|s| !s.is_empty())
             .map(to_snake)
             .collect()
+    }
+
+    fn build_deps(&self, files: &[FileDescriptorProto]) -> BTreeMap<String, BTreeSet<String>> {
+        let names: HashMap<_, _> = files
+            .iter()
+            .map(|file| (file.name().to_owned(), file.package().to_owned()))
+            .collect();
+        let mut deps: BTreeMap<_, BTreeSet<_>> = BTreeMap::new();
+        for file in files {
+            let names = file
+                .dependency
+                .iter()
+                .filter_map(|dep| names.get(dep))
+                .filter(|dep| *dep != file.package())
+                .map(|s| s.clone());
+            deps.entry(file.package().to_owned())
+                .or_default()
+                .extend(names);
+        }
+        deps
     }
 }
 
@@ -950,6 +1007,7 @@ impl default::Default for Config {
             protoc_args: Vec::new(),
             disable_comments: PathMap::default(),
             mod_rs: false,
+            manifest_tpl: None,
         }
     }
 }

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -128,7 +128,8 @@ use std::process::Command;
 
 use log::trace;
 use prost::Message;
-use prost_types::{FileDescriptorProto, FileDescriptorSet};
+use prost_types::compiler::code_generator_response::File;
+use prost_types::{compiler::*, FileDescriptorProto, FileDescriptorSet};
 
 pub use crate::ast::{Comments, Method, Service};
 use crate::code_generator::CodeGenerator;
@@ -791,6 +792,31 @@ impl Config {
         }
 
         Ok(())
+    }
+
+    /// Compile `.proto` code into Rust code from a protoc build with additional code generator
+    /// configuration options.
+    pub fn compile_request(&mut self, req: CodeGeneratorRequest) -> CodeGeneratorResponse {
+        match self.generate(req.proto_file) {
+            Ok(modules) => {
+                let f = modules.into_iter().map(|(module, content)| File {
+                    name: Some(module.join(".") + ".rs"),
+                    insertion_point: None,
+                    content: Some(content),
+                    generated_code_info: None,
+                });
+                CodeGeneratorResponse {
+                    error: None,
+                    supported_features: None,
+                    file: f.collect(),
+                }
+            }
+            Err(e) => CodeGeneratorResponse {
+                error: Some(e.to_string()),
+                supported_features: None,
+                file: Vec::new(),
+            },
+        }
     }
 
     fn generate(&mut self, files: Vec<FileDescriptorProto>) -> Result<HashMap<Module, String>> {

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -113,6 +113,7 @@ mod ast;
 mod code_generator;
 mod extern_paths;
 mod ident;
+mod lib_generator;
 mod message_graph;
 mod path;
 
@@ -135,6 +136,7 @@ pub use crate::ast::{Comments, Method, Service};
 use crate::code_generator::CodeGenerator;
 use crate::extern_paths::ExternPaths;
 use crate::ident::to_snake;
+use crate::lib_generator::{LibGenerator, Mod};
 use crate::message_graph::MessageGraph;
 use crate::path::PathMap;
 
@@ -225,7 +227,8 @@ const COMPILE_WELL_KNOWN_TYPES: &str = "compile_well_known_types";
 const DISABLE_COMMENTS: &str = "disable_comments";
 const EXTERN_PATH: &str = "extern_path";
 const RETAIN_ENUM_PREFIX: &str = "retain_enum_prefix";
-pub const PROTOC_OPTS: [&str; 8] = [
+const MOD_RS: &str = "mod_rs";
+pub const PROTOC_OPTS: [&str; 9] = [
     BTREE_MAP,
     BYTES,
     FIELD_ATTR,
@@ -234,6 +237,7 @@ pub const PROTOC_OPTS: [&str; 8] = [
     DISABLE_COMMENTS,
     EXTERN_PATH,
     RETAIN_ENUM_PREFIX,
+    MOD_RS,
 ];
 
 /// Configuration options for Protobuf code generation.
@@ -252,6 +256,7 @@ pub struct Config {
     extern_paths: Vec<(String, String)>,
     protoc_args: Vec<OsString>,
     disable_comments: PathMap<()>,
+    mod_rs: bool,
 }
 
 impl Config {
@@ -288,6 +293,7 @@ impl Config {
                 [DISABLE_COMMENTS, v] => self.disable_comments.insert(v.to_string(), ()),
                 [EXTERN_PATH, k, v] => self.extern_paths.push((k.to_string(), v.to_string())),
                 [RETAIN_ENUM_PREFIX] => self.strip_enum_prefix = false,
+                [MOD_RS] => self.mod_rs = true,
                 _ if log_unknown => eprintln!("prost: Unknown option `{}`", opt.join("=")),
                 _ => (),
             }
@@ -735,6 +741,12 @@ impl Config {
         self
     }
 
+    /// Generate a `mod.rs` file suitable for a full module.
+    pub fn mod_rs(&mut self) -> &mut Self {
+        self.mod_rs = true;
+        self
+    }
+
     /// Compile `.proto` files into Rust files during a Cargo build with additional code generator
     /// configuration options.
     ///
@@ -901,6 +913,15 @@ impl Config {
             }
         }
 
+        if self.mod_rs {
+            let mut mods = Mod::default();
+            for (module, _) in &modules {
+                mods.push(module);
+            }
+            let mut buf = modules.entry(vec!["mod".to_owned()]).or_default();
+            LibGenerator::generate_librs(self, &mods, &mut buf);
+        }
+
         Ok(modules)
     }
 
@@ -928,6 +949,7 @@ impl default::Default for Config {
             extern_paths: Vec::new(),
             protoc_args: Vec::new(),
             disable_comments: PathMap::default(),
+            mod_rs: false,
         }
     }
 }

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -127,6 +127,7 @@ use std::io::{Error, ErrorKind, Result};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use itertools::Itertools;
 use log::trace;
 use prost::Message;
 use prost_types::compiler::code_generator_response::File;
@@ -227,9 +228,10 @@ const COMPILE_WELL_KNOWN_TYPES: &str = "compile_well_known_types";
 const DISABLE_COMMENTS: &str = "disable_comments";
 const EXTERN_PATH: &str = "extern_path";
 const RETAIN_ENUM_PREFIX: &str = "retain_enum_prefix";
+const FILE_DESCRIPTOR_SET: &str = "file_descriptor_set";
 const MOD_RS: &str = "mod_rs";
 const GEN_CRATE: &str = "gen_crate";
-pub const PROTOC_OPTS: [&str; 10] = [
+pub const PROTOC_OPTS: [&str; 11] = [
     BTREE_MAP,
     BYTES,
     FIELD_ATTR,
@@ -238,6 +240,7 @@ pub const PROTOC_OPTS: [&str; 10] = [
     DISABLE_COMMENTS,
     EXTERN_PATH,
     RETAIN_ENUM_PREFIX,
+    FILE_DESCRIPTOR_SET,
     MOD_RS,
     GEN_CRATE,
 ];
@@ -296,6 +299,10 @@ impl Config {
                 [DISABLE_COMMENTS, v] => self.disable_comments.insert(v.to_string(), ()),
                 [EXTERN_PATH, k, v] => self.extern_paths.push((k.to_string(), v.to_string())),
                 [RETAIN_ENUM_PREFIX] => self.strip_enum_prefix = false,
+                [FILE_DESCRIPTOR_SET] => {
+                    self.file_descriptor_set_path = Some("file_descriptor_set".into())
+                }
+                [FILE_DESCRIPTOR_SET, v] => self.file_descriptor_set_path = Some(v.into()),
                 [MOD_RS] => self.mod_rs = true,
                 [GEN_CRATE, v] => self.manifest_tpl = Some(v.into()),
                 _ if log_unknown => eprintln!("prost: Unknown option `{}`", opt.join("=")),
@@ -880,6 +887,31 @@ impl Config {
     /// Compile `.proto` code into Rust code from a protoc build with additional code generator
     /// configuration options.
     pub fn compile_request(&mut self, req: CodeGeneratorRequest) -> CodeGeneratorResponse {
+        // Optionally output the file descriptor set
+        let set = self.file_descriptor_set_path.clone().map(|path| {
+            let name = self.filename(&vec![path.to_str().unwrap().to_owned()]);
+
+            let set = FileDescriptorSet {
+                file: req.proto_file.clone(),
+            };
+            let mut buf = Vec::new();
+            set.encode(&mut buf).unwrap();
+
+            let buf = buf.into_iter().chunks(16);
+            let lines = buf
+                .into_iter()
+                .map(|chunk| chunk.map(|byte| format!("0x{:02x}", byte)).join(", "))
+                .join(",\n    ");
+            let content =
+                "pub const FILE_DESCRIPTOR_SET: &[u8] = &[\n    ".to_owned() + &lines + ",\n];\n";
+
+            vec![File {
+                name: Some(name),
+                content: Some(content),
+                ..Default::default()
+            }]
+        });
+
         match self.generate(req.proto_file) {
             Ok(modules) => {
                 let f = modules.into_iter().map(|(module, content)| File {
@@ -891,7 +923,7 @@ impl Config {
                 CodeGeneratorResponse {
                     error: None,
                     supported_features: None,
-                    file: f.collect(),
+                    file: f.chain(set.unwrap_or_default()).collect(),
                 }
             }
             Err(e) => CodeGeneratorResponse {

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -947,11 +947,10 @@ impl Config {
     fn generate(&mut self, files: Vec<FileDescriptorProto>) -> Result<HashMap<Module, String>> {
         let mut modules = HashMap::new();
         let mut packages = HashMap::new();
-        let deps = self
-            .manifest_tpl
-            .is_some()
-            .then(|| self.build_deps(&files))
-            .unwrap_or_default();
+        let deps = match self.manifest_tpl {
+            Some(_) => self.build_deps(&files),
+            None => Default::default(),
+        };
 
         let message_graph = MessageGraph::new(&files)
             .map_err(|error| Error::new(ErrorKind::InvalidInput, error))?;
@@ -982,7 +981,7 @@ impl Config {
             for (module, _) in &modules {
                 mods.push(module);
             }
-            let name = self.manifest_tpl.is_some().then(|| "lib").unwrap_or("mod");
+            let name = self.manifest_tpl.as_ref().map(|_| "lib").unwrap_or("mod");
             let mut buf = modules.entry(vec![name.to_owned()]).or_default();
             LibGenerator::generate_librs(self, &mods, &mut buf);
         }

--- a/prost-build/src/lib_generator.rs
+++ b/prost-build/src/lib_generator.rs
@@ -1,0 +1,79 @@
+use std::collections::BTreeMap;
+
+use crate::{Config, Module};
+
+#[derive(Debug)]
+pub struct Mod {
+    submodules: BTreeMap<String, Mod>,
+    contents: Vec<Module>,
+}
+
+impl Mod {
+    pub fn push(&mut self, module: &Module) {
+        match module.as_slice() {
+            [] => (),
+            [name, left @ ..] => self.add(module.to_owned(), name, left),
+        }
+    }
+
+    fn add(&mut self, module: Module, name: &str, left: &[String]) {
+        let sub = self.submodules.entry(name.to_owned()).or_default();
+        match left {
+            [] => sub.contents.push(module),
+            [name, left @ ..] => sub.add(module, name, left),
+        }
+    }
+}
+
+impl Default for Mod {
+    fn default() -> Self {
+        Self {
+            submodules: BTreeMap::new(),
+            contents: Vec::new(),
+        }
+    }
+}
+
+pub struct LibGenerator<'a> {
+    config: &'a mut Config,
+    depth: u8,
+    buf: &'a mut String,
+}
+
+impl<'a> LibGenerator<'a> {
+    pub fn generate_librs(config: &'a mut Config, mods: &Mod, buf: &'a mut String) {
+        let mut generator = LibGenerator {
+            config,
+            depth: 0,
+            buf,
+        };
+        generator.push_mod(mods);
+    }
+
+    fn push_mod(&mut self, mods: &Mod) {
+        for (name, mods) in &mods.submodules {
+            self.push_indent();
+            self.buf.push_str("pub mod ");
+            self.buf.push_str(name);
+            self.buf.push_str(" {\n");
+            self.depth += 1;
+            self.push_mod(&mods);
+            self.depth -= 1;
+            self.push_indent();
+            self.buf.push_str("}\n");
+        }
+
+        for package in mods.contents.iter().map(|content| content.join(".")) {
+            self.push_indent();
+            self.buf.push_str("include!(\"");
+            self.buf.push_str(&package);
+            self.buf.push_str(".rs\");\n");
+        }
+    }
+
+    fn push_indent(&mut self) {
+        for _ in 0..self.depth {
+            self.buf.push_str("    ");
+        }
+    }
+}

--- a/prost-build/src/lib_generator.rs
+++ b/prost-build/src/lib_generator.rs
@@ -49,7 +49,20 @@ impl<'a> LibGenerator<'a> {
             depth: 0,
             buf,
         };
+
+        if let Some(set) = generator.config.file_descriptor_set_path.clone() {
+            generator.push_file_descriptor_set(set);
+        }
         generator.push_mod(mods);
+    }
+
+    fn push_file_descriptor_set(&mut self, set_path: PathBuf) {
+        self.buf.push_str("include!(\"");
+        if self.config.manifest_tpl.is_some() {
+            self.buf.push_str("../gen/");
+        }
+        self.buf.push_str(set_path.to_str().unwrap());
+        self.buf.push_str(".rs\");\n");
     }
 
     fn push_mod(&mut self, mods: &Mod) {

--- a/protoc-gen-prost/Cargo.toml
+++ b/protoc-gen-prost/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "protoc-gen-prost"
+version = "0.8.0"
+authors = ["Tokio Contributors <team@tokio.rs>"]
+license = "Apache-2.0"
+repository = "https://github.com/tokio-rs/prost"
+documentation = "https://docs.rs/prost-build"
+readme = "README.md"
+description = "A Protocol Buffers implementation for the Rust Language."
+edition = "2018"
+
+[dependencies]
+prost = { version = "0.8.0", path = "..", default-features = false }
+prost-build = { version = "0.8.0", path = "../prost-build", default-features = false }
+prost-types = { version = "0.8.0", path = "../prost-types", default-features = false }

--- a/protoc-gen-prost/src/main.rs
+++ b/protoc-gen-prost/src/main.rs
@@ -1,0 +1,26 @@
+use std::io::{Read, Result, Write};
+
+use prost::Message;
+use prost_build::Config;
+use prost_types::compiler::CodeGeneratorRequest;
+
+fn main() {
+    if let Err(e) = faillible_main() {
+        eprintln!("{}", e);
+        std::process::exit(1);
+    }
+}
+
+fn faillible_main() -> Result<()> {
+    let mut buf = Vec::new();
+    std::io::stdin().read_to_end(&mut buf)?;
+
+    let req = CodeGeneratorRequest::decode(buf.as_slice()).unwrap();
+    let res = Config::new_from_opts(req.parameter(), true).compile_request(req);
+
+    buf.clear();
+    res.encode(&mut buf).unwrap();
+    std::io::stdout().write_all(&buf)?;
+
+    Ok(())
+}


### PR DESCRIPTION
Current prost assumes the presence of
`FileDescriptorProto.source_code_info`, this is used to generate and
attach comments from the protobuf files.

As per the specification this field is optional and is not always set in
every protobuf toolchain.

```proto
  // This field contains optional information about the original source code.
  // You may safely remove this entire field without harming runtime
  // functionality of the descriptors -- the information is needed only by
  // development tools.
  optional SourceCodeInfo source_code_info = 9;
```

This appears in complex rules like those present with bazel. The
sequence here is as follows:

1) The descriptor set is generated initially with protoc

```sh
  protoc \
    '--descriptor_set_out=…/xyz_proto-descriptor-set.proto.bin' \
    '-Iprotos/barcode.proto=…/xyz.proto' \
    --direct_dependencies …/xyz.proto \
    '--direct_dependencies_violation_msg=%s is imported but not used …' \
    protos/barcode.proto
```

2) This is then given to the generator plugin

```sh
  protoc \
    --descriptor_set_in=…/xyz_proto-descriptor-set.proto.bin \
    --plugin=protoc-gen-rust_plugin=…/protoc-gen-prost \
    --rust_plugin_out=…/_rpg_premerge_test_pb \
    protos/barcode.proto
```

Notice that the following flag (and, naturally, its effects) was not given to
protoc

```sh
  --include_source_info       When using --descriptor_set_out, do not strip
                              SourceCodeInfo from the FileDescriptorProto.
                              This results in vastly larger descriptors that
                              include information about the original
                              location of each decl in the source file as
                              well as surrounding comments.
```

This results in protobuf compilation failing as we attempt to unwrap the
`Option<SourceCodeInfo>`.

As such the code is changed to account for this. While it is possible to
specify the `--include_source_info` flag (and IMHO this is probably a good
idea) it is not gaurenteed to be the default behaviour of preexisting
toolchains.

With the behaviour of treating the optional sourcecode information as per the
protobuf definition this plugin will behave in the same fashion as most other
known protoc plugins.